### PR TITLE
Add SVG export for plots and TSV export for tables

### DIFF
--- a/pyopenms_viewer/panels/features_table_panel.py
+++ b/pyopenms_viewer/panels/features_table_panel.py
@@ -98,6 +98,17 @@ class FeaturesTablePanel(BasePanel):
                 "dense size=sm color=grey"
             )
 
+            ui.element("div").classes("flex-grow")  # Spacer
+
+            # Export button
+            ui.button(
+                "Export TSV",
+                icon="download",
+                on_click=self._export_tsv
+            ).props("dense outline size=sm color=grey").tooltip(
+                "Export filtered table data as TSV"
+            )
+
     def _build_table(self):
         """Build the features table."""
         columns = [
@@ -253,6 +264,58 @@ class FeaturesTablePanel(BasePanel):
 
         except Exception as e:
             ui.notify(f"Error zooming to feature: {e}", type="negative")
+
+    def _export_tsv(self):
+        """Export filtered table data as TSV file."""
+        data = self._get_filtered_data()
+        if not data:
+            ui.notify("No data to export", type="warning")
+            return
+
+        # Column definitions matching the table
+        columns = [
+            {"field": "idx", "label": "#"},
+            {"field": "rt", "label": "RT (s)"},
+            {"field": "mz", "label": "m/z"},
+            {"field": "intensity", "label": "Intensity"},
+            {"field": "charge", "label": "Z"},
+            {"field": "quality", "label": "Quality"},
+        ]
+        column_fields = [col["field"] for col in columns]
+        column_labels = [col["label"] for col in columns]
+
+        # Build TSV content
+        lines = ["\t".join(column_labels)]  # Header row
+        for row in data:
+            values = []
+            for field in column_fields:
+                val = row.get(field, "")
+                # Convert None to empty string, format numbers
+                if val is None:
+                    val = ""
+                elif isinstance(val, float):
+                    val = f"{val:.4f}" if abs(val) < 1000 else f"{val:.2e}"
+                else:
+                    val = str(val)
+                values.append(val)
+            lines.append("\t".join(values))
+
+        tsv_content = "\n".join(lines)
+
+        # Escape backticks for JavaScript template literal
+        escaped_content = tsv_content.replace("`", "\\`")
+
+        # Trigger download using JavaScript
+        ui.run_javascript(f'''
+            const blob = new Blob([`{escaped_content}`], {{type: "text/tab-separated-values"}});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "features_table.tsv";
+            a.click();
+            URL.revokeObjectURL(url);
+        ''')
+        ui.notify(f"Exported {len(data)} rows", type="positive")
 
     def set_on_feature_selected(self, callback: Callable):
         """Set callback for when a feature is selected.

--- a/pyopenms_viewer/panels/spectrum_panel.py
+++ b/pyopenms_viewer/panels/spectrum_panel.py
@@ -255,7 +255,17 @@ class SpectrumPanel(BasePanel):
 
     def _build_spectrum_plot(self):
         """Build the spectrum plot area."""
+        # Configure Plotly with SVG export option
+        plotly_config = {
+            "toImageButtonOptions": {
+                "format": "svg",
+                "filename": "spectrum",
+                "scale": 1,
+            },
+            "displaylogo": False,
+        }
         self.spectrum_plot = ui.plotly(go.Figure()).classes("w-full")
+        self.spectrum_plot._props["config"] = plotly_config
 
         # Event handlers
         self.spectrum_plot.on("plotly_click", self._on_plot_click)

--- a/pyopenms_viewer/panels/tic_panel.py
+++ b/pyopenms_viewer/panels/tic_panel.py
@@ -34,7 +34,17 @@ class TICPanel(BasePanel):
                 ui.label("Click to view spectrum, drag to zoom RT range").classes(
                     "text-xs text-gray-500 mb-1"
                 )
+                # Configure Plotly with SVG export option
+                plotly_config = {
+                    "toImageButtonOptions": {
+                        "format": "svg",
+                        "filename": "tic",
+                        "scale": 1,
+                    },
+                    "displaylogo": False,
+                }
                 self.plot = ui.plotly(self._create_figure()).classes("w-full")
+                self.plot._props["config"] = plotly_config
                 # Only register events we actually need to avoid large websocket messages
                 self.plot.on("plotly_click", self._on_click)
                 # Note: plotly_selected removed - use plotly_relayout for zooming instead


### PR DESCRIPTION
- Enable SVG export in Plotly modebar for spectrum, TIC, and chromatogram panels
- Add TSV export buttons to spectra table, features table, and chromatogram table panels
- Export uses filtered/visible data and maintains column ordering