### PR TITLE
imzML support  using pyimzML

### DIFF
--- a/pyopenms_viewer/app.py
+++ b/pyopenms_viewer/app.py
@@ -14,7 +14,7 @@ from nicegui import app, run, ui
 from pyopenms_viewer.components.file_picker_storage import get_last_directory
 from pyopenms_viewer.components.local_file_picker import LocalFilePicker
 from pyopenms_viewer.core.state import ViewerState
-from pyopenms_viewer.loaders import FeatureLoader, IDLoader, MzMLLoader
+from pyopenms_viewer.loaders import FeatureLoader, IDLoader, ImzMLLoader, MzMLLoader
 from pyopenms_viewer.panels import (
     ChromatogramPanel,
     ExportPanel,
@@ -33,6 +33,10 @@ from pyopenms_viewer.panels import (
 # Map of filepath -> asyncio.Event used to signal completion of an in-progress load
 _LOAD_EVENTS: dict[str, asyncio.Event] = {}
 _LOAD_EVENTS_LOCK = asyncio.Lock()
+
+# Temporary directories used for pairing imzML + ibd uploads.
+# Key: lowercase file stem; value: Path to temp directory.
+_IMZML_UPLOAD_DIRS: dict[str, Path] = {}
 
 
 async def create_ui():
@@ -147,13 +151,14 @@ async def create_ui():
 
             def _update_info_label(name: str) -> int:
                 """Build info text from state, update the info label, and return peak count."""
-                if state.data_manager is not None:
-                    peak_count = state.data_manager.get_peak_count()
-                elif state.df is not None:
+                if state.df is not None:
                     peak_count = len(state.df)
                 else:
                     peak_count = state.total_peaks
-                info_text = f"Loaded: {name} | Spectra: {len(state.exp):,} | Peaks: {peak_count:,}"
+                n_spectra = len(state.exp) if state.exp is not None else len(state.spectrum_data)
+                info_text = f"Loaded: {name} | Spectra: {n_spectra:,} | Peaks: {peak_count:,}"
+                if state.has_imzml:
+                    info_text = f"Loaded: {name} | Pixels: {n_spectra:,} | Peaks: {peak_count:,}"
                 if state.has_faims:
                     info_text += f" | FAIMS: {len(state.faims_cvs)} CVs"
                 if state.out_of_core:
@@ -259,6 +264,7 @@ async def create_ui():
                     progress_label.set_text("Rendering...")
                     await asyncio.sleep(0)  # Let UI update before heavy renders
                     state.emit_data_loaded("mzml")
+                    state.update_panel_visibility()
                     progress_label.set_text("")
                     peak_count = _update_info_label(name)
                     safe_notify(f"Loaded {peak_count:,} peaks from {name}", type="positive")
@@ -267,6 +273,45 @@ async def create_ui():
 
             # Store loaders in state for use by panels
             state._load_mzml = load_mzml
+
+            async def load_imzml(filepath: str, original_name: str = None):
+                """Load an imzML/ibd file pair in the background.
+
+                The .ibd binary must be alongside the .imzML file on disk.
+                """
+                loader = ImzMLLoader(state)
+                name = original_name or Path(filepath).name
+
+                def _progress_cb(message: str, progress: float) -> None:
+                    try:
+                        state.load_progress[filepath] = (message, float(progress))
+                    except Exception:
+                        pass
+
+                safe_notify(f"Loading {name}…", type="info")
+                try:
+                    success = await run.io_bound(loader.load_sync, filepath, _progress_cb)
+                finally:
+                    try:
+                        state.load_progress.pop(filepath, None)
+                    except Exception:
+                        pass
+
+                if success:
+                    _relink_ids_and_update_label()
+                    progress_label.set_text("Rendering...")
+                    await asyncio.sleep(0)
+                    state.emit_data_loaded("mzml")
+                    state.update_panel_visibility()
+                    progress_label.set_text("")
+                    peak_count = _update_info_label(name)
+                    safe_notify(f"Loaded {peak_count:,} peaks from {name}", type="positive")
+                else:
+                    err = getattr(state, "_last_load_error", "") or ""
+                    safe_notify(
+                        f"Failed to load {name}" + (f": {err}" if err else ""),
+                        type="negative",
+                    )
 
             async def handle_upload(e):
                 """Handle uploaded file - detect type and load appropriately.
@@ -287,6 +332,46 @@ async def create_ui():
                 try:
                     if filename.endswith(".mzml"):
                         await load_mzml(tmp_path, original_name)
+
+                    elif filename.endswith(".imzml"):
+                        # imzML needs a paired .ibd file; accumulate both in a temp dir
+                        stem = Path(filename).stem.lower()
+                        tmpdir = _IMZML_UPLOAD_DIRS.get(stem)
+                        if tmpdir is None:
+                            tmpdir = Path(tempfile.mkdtemp())
+                            _IMZML_UPLOAD_DIRS[stem] = tmpdir
+                        imzml_dest = tmpdir / Path(original_name).name
+                        import shutil
+                        shutil.copy2(tmp_path, str(imzml_dest))
+                        ibd_dest = tmpdir / (Path(original_name).stem + ".ibd")
+                        if ibd_dest.exists():
+                            await load_imzml(str(imzml_dest), original_name)
+                            _IMZML_UPLOAD_DIRS.pop(stem, None)
+                        else:
+                            ui.notify(
+                                f"Uploaded {original_name}. Please also upload the paired .ibd file.",
+                                type="info",
+                            )
+
+                    elif filename.endswith(".ibd"):
+                        # Accumulate .ibd in the same temp dir as its .imzml
+                        stem = Path(filename).stem.lower()
+                        tmpdir = _IMZML_UPLOAD_DIRS.get(stem)
+                        if tmpdir is None:
+                            tmpdir = Path(tempfile.mkdtemp())
+                            _IMZML_UPLOAD_DIRS[stem] = tmpdir
+                        ibd_dest = tmpdir / Path(original_name).name
+                        import shutil
+                        shutil.copy2(tmp_path, str(ibd_dest))
+                        imzml_candidates = list(tmpdir.glob("*.imzML")) + list(tmpdir.glob("*.imzml"))
+                        if imzml_candidates:
+                            await load_imzml(str(imzml_candidates[0]), imzml_candidates[0].name)
+                            _IMZML_UPLOAD_DIRS.pop(stem, None)
+                        else:
+                            ui.notify(
+                                f"Uploaded {original_name}. Please also upload the paired .imzML file.",
+                                type="info",
+                            )
 
                     elif filename.endswith(".featurexml") or (filename.endswith(".xml") and "feature" in filename):
                         loader = FeatureLoader(state)
@@ -355,6 +440,8 @@ async def create_ui():
                         try:
                             if ext == ".mzml":
                                 await load_mzml(filepath, name)
+                            elif ext == ".imzml":
+                                await load_imzml(filepath, name)
                             elif ext == ".featurexml":
                                 loader = FeatureLoader(state)
                                 success = await run.io_bound(loader.load_sync, filepath)
@@ -393,6 +480,8 @@ async def create_ui():
                     try:
                         if ext == ".mzml":
                             await load_mzml(filepath, name)
+                        elif ext == ".imzml":
+                            await load_imzml(filepath, name)
                         elif ext == ".featurexml":
                             loader = FeatureLoader(state)
                             success = await run.io_bound(loader.load_sync, filepath)
@@ -437,7 +526,7 @@ async def create_ui():
 
             with upload_container:
                 ui.upload(on_upload=handle_upload, auto_upload=True, multiple=True).props(
-                    'hide-upload-btn no-thumbnails accept=".mzML,.mzml,.featureXML,.featurexml,.idXML,.idxml,.xml"'
+                    'hide-upload-btn no-thumbnails accept=".mzML,.mzml,.imzML,.imzml,.ibd,.featureXML,.featurexml,.idXML,.idxml,.xml"'
                 ).classes("w-full border rounded")
 
             ui.separator().props("vertical").classes("h-6")
@@ -935,6 +1024,9 @@ async def create_ui():
 
         if cli_files["mzml"]:
             await load_mzml(cli_files["mzml"])
+
+        if cli_files.get("imzml"):
+            await load_imzml(cli_files["imzml"])
 
         if cli_files["featurexml"]:
             loader = FeatureLoader(state)

--- a/pyopenms_viewer/app.py
+++ b/pyopenms_viewer/app.py
@@ -151,7 +151,9 @@ async def create_ui():
 
             def _update_info_label(name: str) -> int:
                 """Build info text from state, update the info label, and return peak count."""
-                if state.df is not None:
+                if state.data_manager is not None and state.data_manager._peaks_registered:
+                    peak_count = state.data_manager.get_peak_count()
+                elif state.df is not None:
                     peak_count = len(state.df)
                 else:
                     peak_count = state.total_peaks

--- a/pyopenms_viewer/cli.py
+++ b/pyopenms_viewer/cli.py
@@ -136,6 +136,8 @@ def main(files, port, host, open_browser, native, dark, out_of_core, cache_dir):
         ext = path.suffix.lower()
         if ext == ".mzml":
             _cli_files["mzml"] = str(path.absolute())
+        elif ext == ".imzml":
+            _cli_files["imzml"] = str(path.absolute())
         elif ext == ".featurexml":
             _cli_files["featurexml"] = str(path.absolute())
         elif ext == ".idxml":

--- a/pyopenms_viewer/components/local_file_picker.py
+++ b/pyopenms_viewer/components/local_file_picker.py
@@ -24,6 +24,8 @@ from pyopenms_viewer.components.file_picker_storage import (
 # Map of file extensions to (icon, type label)
 _FILE_TYPE_INFO: dict[str, tuple[str, str]] = {
     ".mzml": ("science", "mzML File"),
+    ".imzml": ("biotech", "imzML File"),
+    ".ibd": ("storage", "imzML Binary Data"),
     ".featurexml": ("scatter_plot", "featureXML File"),
     ".idxml": ("fingerprint", "idXML File"),
     ".xml": ("code", "XML File"),
@@ -44,7 +46,7 @@ def _human_readable_size(size_bytes: int) -> str:
 class LocalFilePicker(ui.dialog):
     """A dialog for picking files from the local filesystem."""
 
-    SUPPORTED_EXTENSIONS = {".mzml", ".featurexml", ".idxml", ".xml"}
+    SUPPORTED_EXTENSIONS = {".mzml", ".imzml", ".ibd", ".featurexml", ".idxml", ".xml"}
 
     def __init__(
         self,

--- a/pyopenms_viewer/core/state.py
+++ b/pyopenms_viewer/core/state.py
@@ -132,6 +132,7 @@ class ViewerState:
         self.view_im_max: Optional[float] = None
 
         # ========== FLAGS ==========
+        self.has_imzml: bool = False  # True when an imzML/ibd file pair is loaded
         self.has_faims: bool = False
         self.has_ion_mobility: bool = False
         self.has_chromatograms: bool = False
@@ -150,6 +151,8 @@ class ViewerState:
         self.current_file: Optional[str] = None
         self.features_file: Optional[str] = None
         self.id_file: Optional[str] = None
+        # Last load error message (set by loaders on failure)
+        self._last_load_error: str = ""
         # Tracks files currently being loaded to avoid duplicate concurrent loads
         self._loading_files: set[str] = set()
         # Thread-safe events for threads waiting on an in-progress load
@@ -847,6 +850,8 @@ class ViewerState:
         self.zoom_history = []
         self.spectrum_measurements = {}
         self.peak_annotations = {}
+        self.has_imzml = False
+        self._last_load_error = ""
 
     def clear_feature_data(self) -> None:
         """Clear feature-related data."""

--- a/pyopenms_viewer/loaders/__init__.py
+++ b/pyopenms_viewer/loaders/__init__.py
@@ -1,14 +1,16 @@
-"""Data loaders for mzML, featureXML, idXML, and related formats."""
+"""Data loaders for mzML, featureXML, idXML, imzML, and related formats."""
 
 from pyopenms_viewer.loaders.chromatogram_loader import extract_chromatograms
 from pyopenms_viewer.loaders.feature_loader import FeatureLoader, extract_feature_data
 from pyopenms_viewer.loaders.id_loader import IDLoader, extract_id_data, link_ids_to_spectra
+from pyopenms_viewer.loaders.imzml_loader import ImzMLLoader
 from pyopenms_viewer.loaders.ion_mobility_loader import extract_ion_mobility_data
 from pyopenms_viewer.loaders.mzml_loader import MzMLLoader, get_cv_from_spectrum
 from pyopenms_viewer.loaders.spectrum_extractor import extract_spectrum_data
 
 __all__ = [
     "MzMLLoader",
+    "ImzMLLoader",
     "FeatureLoader",
     "IDLoader",
     "get_cv_from_spectrum",

--- a/pyopenms_viewer/loaders/imzml_loader.py
+++ b/pyopenms_viewer/loaders/imzml_loader.py
@@ -38,9 +38,7 @@ class ImzMLLoader:
     def __init__(self, state: ViewerState) -> None:
         self.state = state
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+  
 
     def load_sync(
         self,
@@ -84,9 +82,6 @@ class ImzMLLoader:
                 self.state._last_load_error = "No spectra found in imzML file"
                 return False
 
-            # ----------------------------------------------------------
-            # Phase 1 – iterate pixels and build MSExperiment + peak lists
-            # ----------------------------------------------------------
             from pyopenms import MSExperiment, MSSpectrum
 
             exp = MSExperiment()
@@ -145,9 +140,6 @@ class ImzMLLoader:
                         0.05 + 0.65 * (i + 1) / n_spectra,
                     )
 
-            # ----------------------------------------------------------
-            # Phase 2 – build peak DataFrame
-            # ----------------------------------------------------------
             _prog("Building peak DataFrame…", 0.72)
 
             # Ensure pyOpenMS knows the RT/mz extents (needed by rasterizeRTMZ)
@@ -171,9 +163,7 @@ class ImzMLLoader:
             )
             df["log_intensity"] = np.log1p(df["intensity"])
 
-            # ----------------------------------------------------------
-            # Phase 3 – build spectrum_data table (for spectra table panel)
-            # ----------------------------------------------------------
+       
             _prog("Extracting spectrum metadata…", 0.85)
             from pyopenms_viewer.loaders.spectrum_extractor import extract_spectrum_data
 
@@ -181,9 +171,6 @@ class ImzMLLoader:
             self.state.exp = exp
             spectrum_data = extract_spectrum_data(self.state, spectrum_stats=spectrum_stats)
 
-            # ----------------------------------------------------------
-            # Phase 4 – populate state
-            # ----------------------------------------------------------
             _prog("Updating viewer state…", 0.92)
 
             coords_arr = np.array(parser.coordinates)

--- a/pyopenms_viewer/loaders/imzml_loader.py
+++ b/pyopenms_viewer/loaders/imzml_loader.py
@@ -1,0 +1,240 @@
+"""imzML file loading and processing.
+
+This module handles loading imzML/ibd file pairs using pyimzml and populating
+the ViewerState so that all existing panels (TIC, peak map, spectrum browser,
+spectra table, export) work without modification.
+
+Strategy:
+- Build an MSExperiment where each pixel (x, y, z) becomes one MSSpectrum
+  with RT set to pixel-X.  This lets spectrum_panel, spectra_table, etc.
+  operate exactly as for regular mzML.
+- Build a peak DataFrame (rt=pixel-X, mz, intensity) for the peak-map renderer.
+- Compute a per-pixel-X TIC for the TIC panel.
+- Force rt_in_minutes=False so pixel coordinates are not divided by 60.
+"""
+
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+import pandas as pd
+
+from pyopenms_viewer.core.state import ViewerState
+
+
+class ImzMLLoader:
+    """Loads imzML/ibd file pairs and populates ViewerState.
+
+    The paired .ibd file must reside in the same directory as the .imzML file.
+
+    Example::
+
+        state = ViewerState()
+        loader = ImzMLLoader(state)
+        if loader.load_sync("sample.imzML"):
+            print(f"Loaded {len(state.df):,} peaks from {len(state.exp)} pixels")
+    """
+
+    def __init__(self, state: ViewerState) -> None:
+        self.state = state
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load_sync(
+        self,
+        filepath: str,
+        progress_cb: Optional[Callable[[str, float], None]] = None,
+    ) -> bool:
+        """Load an imzML file synchronously (blocking).
+
+        Args:
+            filepath: Absolute path to the ``.imzML`` file.
+                      The ``.ibd`` binary must be alongside it.
+            progress_cb: Optional ``(message, fraction)`` callback for progress
+                         reporting (fraction in ``[0.0, 1.0]``).
+
+        Returns:
+            ``True`` on success, ``False`` on failure.
+            On failure ``state._last_load_error`` is set to an error string.
+        """
+        try:
+            from pyimzml.ImzMLParser import ImzMLParser
+        except ImportError:
+            self.state._last_load_error = (
+                "pyimzml is not installed. Install with: pip install pyimzml"
+            )
+            return False
+
+        def _prog(msg: str, frac: float) -> None:
+            if progress_cb:
+                try:
+                    progress_cb(msg, frac)
+                except Exception:
+                    pass
+
+        try:
+            path = Path(filepath)
+            _prog("Opening imzML file…", 0.0)
+            parser = ImzMLParser(str(path))
+
+            n_spectra = len(parser.coordinates)
+            if n_spectra == 0:
+                self.state._last_load_error = "No spectra found in imzML file"
+                return False
+
+            # ----------------------------------------------------------
+            # Phase 1 – iterate pixels and build MSExperiment + peak lists
+            # ----------------------------------------------------------
+            from pyopenms import MSExperiment, MSSpectrum
+
+            exp = MSExperiment()
+
+            all_rt: list[float] = []
+            all_mz: list[np.ndarray] = []
+            all_int: list[np.ndarray] = []
+
+            # Accumulate per-x TIC (summed over all y, z at the same x)
+            tic_by_x: dict[int, float] = {}
+
+            spectrum_stats: list[dict] = []
+
+            _prog("Loading pixel spectra…", 0.05)
+            for i, (x, y, z) in enumerate(parser.coordinates):
+                mz_arr, int_arr = parser.getspectrum(i)
+                mz_arr = np.asarray(mz_arr, dtype=np.float64)
+                int_arr = np.asarray(int_arr, dtype=np.float64)
+
+                rt = float(x)  # Use pixel X as the "retention time" axis
+
+                # Build MSSpectrum so existing panels can access raw data
+                spec = MSSpectrum()
+                spec.setRT(rt)
+                spec.setMSLevel(1)
+                spec.set_peaks((mz_arr, int_arr))
+                spec.setNativeID(f"pixel x={x} y={y} z={z}")
+                exp.addSpectrum(spec)
+
+                n = len(mz_arr)
+                if n > 0:
+                    all_rt.append(np.full(n, rt, dtype=np.float32))
+                    all_mz.append(mz_arr.astype(np.float32))
+                    all_int.append(int_arr.astype(np.float32))
+
+                tic = float(np.sum(int_arr)) if n > 0 else 0.0
+                bpi = float(np.max(int_arr)) if n > 0 else 0.0
+                mz_min_v = float(mz_arr.min()) if n > 0 else 0.0
+                mz_max_v = float(mz_arr.max()) if n > 0 else 0.0
+
+                tic_by_x[x] = tic_by_x.get(x, 0.0) + tic
+
+                spectrum_stats.append(
+                    {
+                        "tic": tic,
+                        "bpi": bpi,
+                        "mz_min": mz_min_v,
+                        "mz_max": mz_max_v,
+                        "cv": None,
+                    }
+                )
+
+                if i % 200 == 0:
+                    _prog(
+                        f"Loading pixel spectra… {i + 1}/{n_spectra}",
+                        0.05 + 0.65 * (i + 1) / n_spectra,
+                    )
+
+            # ----------------------------------------------------------
+            # Phase 2 – build peak DataFrame
+            # ----------------------------------------------------------
+            _prog("Building peak DataFrame…", 0.72)
+
+            # Ensure pyOpenMS knows the RT/mz extents (needed by rasterizeRTMZ)
+            exp.updateRanges()
+
+            if all_rt:
+                rt_col = np.concatenate(all_rt)
+                mz_col = np.concatenate(all_mz)
+                int_col = np.concatenate(all_int)
+            else:
+                rt_col = np.array([], dtype=np.float32)
+                mz_col = np.array([], dtype=np.float32)
+                int_col = np.array([], dtype=np.float32)
+
+            df = pd.DataFrame(
+                {
+                    "rt": rt_col,
+                    "mz": mz_col,
+                    "intensity": int_col,
+                }
+            )
+            df["log_intensity"] = np.log1p(df["intensity"])
+
+            # ----------------------------------------------------------
+            # Phase 3 – build spectrum_data table (for spectra table panel)
+            # ----------------------------------------------------------
+            _prog("Extracting spectrum metadata…", 0.85)
+            from pyopenms_viewer.loaders.spectrum_extractor import extract_spectrum_data
+
+            # Temporarily assign exp so extract_spectrum_data can iterate it
+            self.state.exp = exp
+            spectrum_data = extract_spectrum_data(self.state, spectrum_stats=spectrum_stats)
+
+            # ----------------------------------------------------------
+            # Phase 4 – populate state
+            # ----------------------------------------------------------
+            _prog("Updating viewer state…", 0.92)
+
+            coords_arr = np.array(parser.coordinates)
+            x_vals = coords_arr[:, 0].astype(float)
+            rt_data_min = float(x_vals.min())
+            rt_data_max = float(x_vals.max())
+
+            if len(df) > 0:
+                mz_data_min = float(df["mz"].min())
+                mz_data_max = float(df["mz"].max())
+            else:
+                mz_data_min, mz_data_max = 0.0, 1.0
+
+            # TIC: sort by x, one entry per unique x (sum of all y/z pixels)
+            sorted_x = sorted(tic_by_x.keys())
+            tic_rt = np.array(sorted_x, dtype=np.float64)
+            tic_int = np.array([tic_by_x[x] for x in sorted_x], dtype=np.float64)
+
+            # Clear any previous mzML data first
+            self.state.clear_mzml_data()
+
+            # Core data
+            self.state.exp = exp
+            self.state.df = df
+            self.state.total_peaks = len(df)
+            self.state.spectrum_data = spectrum_data
+            self.state.current_file = str(path)
+
+            # Bounds
+            self.state.rt_min = rt_data_min
+            self.state.rt_max = rt_data_max
+            self.state.mz_min = mz_data_min
+            self.state.mz_max = mz_data_max
+            self.state.view_rt_min = rt_data_min
+            self.state.view_rt_max = rt_data_max
+            self.state.view_mz_min = mz_data_min
+            self.state.view_mz_max = mz_data_max
+
+            # TIC
+            self.state.tic_rt = tic_rt
+            self.state.tic_intensity = tic_int
+            self.state.tic_source = "MSI Pixel TIC"
+
+            # Flags
+            self.state.has_imzml = True
+            # Pixel coordinates must not be divided by 60 (not time)
+            self.state.rt_in_minutes = False
+
+            _prog("Done", 1.0)
+            return True
+
+        except Exception as ex:
+            self.state._last_load_error = str(ex)
+            return False


### PR DESCRIPTION
The ImzMLLoader uses the ImzMLParser from pyimzml to iterate through every pixel in an .imzML / .ibd file pair. For each pixel (x, y), it reads the m/z and intensity arrays and creates a pyopenms.MSSpectrum, storing the pixel's X coordinate as the retention time.(please check if this needs to change)

After processing all pixels, the spectra are combined into an experiment object and a pandas DataFrame of all peaks is generated. This mirrors the mzML loader structure, allowing existing components like the peak map, spectrum browser etc to work with imzML data seamlessly.



I am attaching videos for your quick reference :
ImzMl test  - 

https://github.com/user-attachments/assets/1ecadbe3-cf56-48e6-82c2-b7bbd10333a2

mzML works as previously intended :

https://github.com/user-attachments/assets/1b6d7b67-63ad-49c6-b919-839e780d034b

 #26 