### PR TITLE
Ion Image panel: review fixes + e2e coverage (builds on #42)

### DIFF
--- a/pyopenms_viewer/app.py
+++ b/pyopenms_viewer/app.py
@@ -371,6 +371,41 @@ async def create_ui():
                     safe_notify(f"File already loaded: {name}", type="info")
                     return
 
+                # Atomically check/create an Event so only one coroutine performs
+                # the actual parse; others wait and reuse the result (mirrors
+                # load_mzml — prevents re-entrant/concurrent duplicate loads).
+                async with _LOAD_EVENTS_LOCK:
+                    existing_event = _LOAD_EVENTS.get(new_fp)
+                    if existing_event is None:
+                        event = asyncio.Event()
+                        _LOAD_EVENTS[new_fp] = event
+                        is_loader = True
+                    else:
+                        event = existing_event
+                        is_loader = False
+
+                if not is_loader:
+                    await event.wait()
+                    if state.current_file:
+                        cur_fp = _resolve_or_str(state.current_file)
+                    if (
+                        state.current_file
+                        and cur_fp == new_fp
+                        and state.has_imzml
+                        and state.msi_experiment is not None
+                    ):
+                        _relink_ids_and_update_label()
+                        state.emit_data_loaded("mzml")
+                        state.update_panel_visibility()
+                        _update_info_label(name)
+                        safe_notify(f"File already loaded: {name}", type="info")
+                        return
+
+                try:
+                    state._loading_files.add(new_fp)
+                except Exception:
+                    pass
+
                 def _progress_cb(message: str, progress: float) -> None:
                     try:
                         state.load_progress[filepath] = (message, float(progress))
@@ -381,6 +416,13 @@ async def create_ui():
                 try:
                     success = await run.io_bound(loader.load_sync, filepath, _progress_cb)
                 finally:
+                    ev = _LOAD_EVENTS.pop(new_fp, None)
+                    if ev is not None:
+                        ev.set()
+                    try:
+                        state._loading_files.discard(new_fp)
+                    except Exception:
+                        pass
                     try:
                         state.load_progress.pop(filepath, None)
                     except Exception:

--- a/pyopenms_viewer/core/state.py
+++ b/pyopenms_viewer/core/state.py
@@ -91,6 +91,10 @@ class ViewerState:
         # In out-of-core mode, df and im_df may be None after registration
         self.exp = None  # MSExperiment - pyOpenMS C++ object (~500MB)
         self.msi_experiment = None  # MSImagingExperiment — set when imzML is loaded
+        # Monotonic counter bumped once per successful imzML load. Panels use it
+        # to dedupe repeated data_loaded emits (page reload / CLI fast-path).
+        # Deliberately NOT reset by clear_mzml_data — only new loads advance it.
+        self.msi_load_token: int = 0
         self.df: pd.DataFrame | None = None  # All peaks: rt, mz, intensity, log_intensity (~2GB)
         self.im_df: pd.DataFrame | None = None  # Ion mobility peaks: mz, im, intensity, log_intensity
         self.faims_data: dict[float, pd.DataFrame] = {}  # CV -> DataFrame (views into self.df)

--- a/pyopenms_viewer/loaders/imzml_loader.py
+++ b/pyopenms_viewer/loaders/imzml_loader.py
@@ -42,6 +42,24 @@ def _apply_pseudo_rt(mie) -> None:
             spec.setMSLevel(1)
 
 
+def _select_positive_intensity_peaks(spec) -> None:
+    """Keep only intensity>0 peaks in ``spec``, in place.
+
+    Uses ``MSSpectrum.select`` (not ``set_peaks``) so that peaks AND all
+    associated FloatDataArrays — e.g. per-peak ion mobility — are filtered
+    together and stay index-aligned. ``set_peaks`` shortens only the m/z /
+    intensity arrays, leaving the ion-mobility array at its original length,
+    which silently breaks IM detection downstream.
+    """
+    _, ints = spec.get_peaks()
+    if len(ints) == 0:
+        return
+    keep = ints > 0
+    if keep.all():
+        return
+    spec.select(np.flatnonzero(keep).tolist())
+
+
 def _drop_zero_intensity_peaks(mie) -> None:
     """Drop intensity==0 peaks from every spectrum in the MSImagingExperiment, in place.
 
@@ -49,16 +67,7 @@ def _drop_zero_intensity_peaks(mie) -> None:
     these inflate peak counts and poison aggregate spectra.
     """
     for spec in mie.getMSExperiment().getSpectra():
-        mzs, ints = spec.get_peaks()
-        if len(ints) == 0:
-            continue
-        keep = ints > 0
-        if keep.all():
-            continue
-        spec.set_peaks((
-            np.array(mzs[keep], dtype=np.float64, copy=True),
-            np.array(ints[keep], dtype=np.float32, copy=True),
-        ))
+        _select_positive_intensity_peaks(spec)
 
 
 class ImzMLLoader:
@@ -237,10 +246,13 @@ class ImzMLLoader:
 
             _prog("Extracting spectrum metadata…", 0.80)
 
-            # Temporarily assign msexp so extract_spectrum_data can iterate it
-            self.state.exp = msexp
+            # Extract against the local msexp WITHOUT mutating shared state, so a
+            # failure here leaves the previous experiment fully intact and the UI
+            # never sees new spectra combined with old geometry/df.
             from pyopenms_viewer.loaders.spectrum_extractor import extract_spectrum_data
-            spectrum_data = extract_spectrum_data(self.state, spectrum_stats=spectrum_stats)
+            spectrum_data = extract_spectrum_data(
+                self.state, spectrum_stats=spectrum_stats, exp=msexp
+            )
 
             _prog("Updating viewer state…", 0.92)
 
@@ -290,18 +302,30 @@ class ImzMLLoader:
 
             # If per-peak ion mobility was detected, populate IM state so the
             # IMPeakMapPanel auto-activates. Reuses MzMLLoader's proven pipeline.
+            # Best-effort: the core imaging load above is already committed and
+            # useful, so an IM-processing failure disables IM rather than
+            # discarding the whole (valid) load.
             if detected_im_name is not None and im_mz_list:
-                from pyopenms_viewer.loaders.mzml_loader import MzMLLoader
-                _im_loader = MzMLLoader(self.state)
-                _im_loader._process_ion_mobility_data(
-                    im_mz_list=im_mz_list,
-                    im_im_list=im_im_list,
-                    im_int_list=im_int_list,
-                    detected_im_name=detected_im_name,
-                    filepath=str(path),
-                    im_frame_indices=im_frame_indices,
-                    im_frame_ms_levels=[1] * len(im_frame_indices),
-                )
+                try:
+                    from pyopenms_viewer.loaders.mzml_loader import MzMLLoader
+                    _im_loader = MzMLLoader(self.state)
+                    _im_loader._process_ion_mobility_data(
+                        im_mz_list=im_mz_list,
+                        im_im_list=im_im_list,
+                        im_int_list=im_int_list,
+                        detected_im_name=detected_im_name,
+                        filepath=str(path),
+                        im_frame_indices=im_frame_indices,
+                        im_frame_ms_levels=[1] * len(im_frame_indices),
+                    )
+                except Exception as im_ex:
+                    self.state.has_ion_mobility = False
+                    self.state.im_df = None
+                    print(f"[ImzMLLoader] ion-mobility processing failed, disabled: {im_ex}")
+
+            # Signal a new imaging dataset. Bumped LAST so panels that key off
+            # this token only react once the full commit above is in place.
+            self.state.msi_load_token += 1
 
             print(
                 f"Loaded {n_spectra} pixels; geometry "

--- a/pyopenms_viewer/loaders/mzml_loader.py
+++ b/pyopenms_viewer/loaders/mzml_loader.py
@@ -487,6 +487,13 @@ class MzMLLoader:
 
             self.state.current_file = filepath
 
+            # Clear any stale MSI state from a previously-loaded imzML so the
+            # Ion Image panel does not keep rendering the old experiment beside
+            # this plain-mzML data (MzMLLoader does not go through
+            # clear_mzml_data). msi_load_token is intentionally left untouched.
+            self.state.has_imzml = False
+            self.state.msi_experiment = None
+
             # Invalidate minimap cache when new file is loaded
             self.state.invalidate_minimap_cache()
 

--- a/pyopenms_viewer/loaders/spectrum_extractor.py
+++ b/pyopenms_viewer/loaders/spectrum_extractor.py
@@ -8,6 +8,8 @@ from pyopenms_viewer.core.state import ViewerState
 def extract_spectrum_data(
     state: ViewerState,
     spectrum_stats: list[dict[str, Any]] | None = None,
+    *,
+    exp=None,
 ) -> list[dict[str, Any]]:
     """Extract spectrum metadata for the unified spectrum table.
 
@@ -15,14 +17,18 @@ def extract_spectrum_data(
     when IDs are loaded via link_ids_to_spectra().
 
     Args:
-        state: ViewerState with exp (MSExperiment) already loaded
+        state: ViewerState (used for ID linkage fields).
         spectrum_stats: Optional pre-computed stats from mzml_loader (tic, bpi, mz_min, mz_max, cv).
                        If provided, avoids redundant get_peaks() calls.
+        exp: Optional MSExperiment to iterate instead of ``state.exp``. Lets a
+             loader extract metadata from a freshly-built experiment without
+             mutating shared state before its atomic commit.
 
     Returns:
         List of spectrum metadata dictionaries
     """
-    if state.exp is None:
+    exp = exp if exp is not None else state.exp
+    if exp is None:
         return []
 
     # Import here to avoid circular dependency (only needed if stats not provided)
@@ -32,8 +38,8 @@ def extract_spectrum_data(
         from pyopenms_viewer.loaders.mzml_loader import get_cv_from_spectrum
 
     data = []
-    for idx in range(len(state.exp)):
-        spec = state.exp[idx]
+    for idx in range(len(exp)):
+        spec = exp[idx]
         rt = spec.getRT()
         ms_level = spec.getMSLevel()
         n_peaks = len(spec)

--- a/pyopenms_viewer/panels/imaging_panel.py
+++ b/pyopenms_viewer/panels/imaging_panel.py
@@ -103,6 +103,20 @@ class ImagingPanel(BasePanel):
         self._agg_centers: np.ndarray | None = None
         self._agg_mean: np.ndarray | None = None
         self._agg_skyline: np.ndarray | None = None
+        # True once the aggregate has been computed for the current dataset,
+        # even if the result was empty. Distinguishes "not computed yet" from
+        # "computed, legitimately empty" so an empty dataset is not recomputed
+        # on every emit / after-show. Reset by _reset_view_and_caches().
+        self._agg_computed: bool = False
+
+        # Rehydration dedupe (see _on_data_loaded). data_loaded("mzml") can be
+        # emitted several times for one load (normal load, page-reload
+        # rehydration, CLI already-loaded fast-path); recompute at most once per
+        # msi_load_token. _pending_token guards emits that arrive before the
+        # deferred render timer fires.
+        self._handled_token: int | None = None
+        self._pending_token: int | None = None
+        self._render_timer = None
 
         # Overlay: list of {"mz", "ppm", "hue", "img"} dicts. Rendered
         # additively into an RGB composite.
@@ -183,11 +197,11 @@ class ImagingPanel(BasePanel):
             return
         # Ensure aggregate cache exists even if after-show raced ahead of
         # ``_on_data_loaded`` (or the panel was opened manually before load).
-        if self._agg_centers is None:
-            try:
-                self._recompute_aggregate()
-            except Exception as exc:
-                print(f"[ImagingPanel] aggregate error (after-show): {exc}")
+        # Routed through _ensure_aggregate so it computes at most once per load.
+        try:
+            self._ensure_aggregate()
+        except Exception as exc:
+            print(f"[ImagingPanel] aggregate error (after-show): {exc}")
         self.update()   # refresh stored figure state
         # Force re-render via JS for scatter-based plots (heatmaps are fine).
         import json as _json
@@ -335,50 +349,146 @@ class ImagingPanel(BasePanel):
     # ------------------------------------------------------------------
 
     def _on_data_loaded(self, data_type: str) -> None:
-        """Rebuild the aggregate cache and render TIC when a new imzML loads."""
+        """React to a data_loaded('mzml') emit; recompute at most once per load.
+
+        The same emit can arrive several times for one dataset (normal load,
+        page-reload rehydration, CLI already-loaded fast-path). We key on
+        ``state.msi_load_token`` so the heavy aggregate runs once, and defer it
+        off the synchronous page-build path so first paint is not blocked.
+        """
         if data_type != "mzml":
             return
-        # Update visibility first so update_figure calls reach a visible element.
-        self.update_visibility()
         if not self._has_data():
+            # Switched to non-imzML data (or state cleared): free imaging memory
+            # and blank the figures. Done BEFORE any early return so large image
+            # arrays are not retained until the next imzML load.
+            self._cancel_render_timer()
+            self._reset_view_and_caches()
+            self._clear_all_figures()
+            self._handled_token = None
+            self._pending_token = None
+            self.update_visibility()
             if self.expansion:
                 self.expansion.value = False
             return
-        self._mode = "tic"
-        self._current_mz = None
-        self._overlay_entries.clear()
+
+        token = self.state.msi_load_token
+        if token == self._handled_token:
+            # Already rendered this dataset — cheap re-render from cache,
+            # preserving the user's current ion / overlay across a no-op emit.
+            self.update_visibility()
+            self.update()
+            return
+        if token == self._pending_token:
+            # Render already scheduled for this dataset; let the timer do it.
+            self.update_visibility()
+            return
+
+        self._reset_view_and_caches()
+        self.update_visibility()
+        self._schedule_initial_render(token)
+
+    # ------------------------------------------------------------------
+    # Rehydration helpers (dedupe + deferred, race-safe first render)
+    # ------------------------------------------------------------------
+
+    def _reset_caches(self) -> None:
+        """Drop cached images and the overlay (free memory)."""
         self._tic_cache = None
         self._ion_cache_key = None
         self._ion_cache_img = None
+        self._overlay_entries.clear()
+
+    def _reset_view_and_caches(self) -> None:
+        """Reset to the default TIC view and drop all per-dataset caches."""
+        self._mode = "tic"
+        self._current_mz = None
+        self._reset_caches()
         self._agg_centers = None
         self._agg_mean = None
         self._agg_skyline = None
+        self._agg_computed = False
         if self._mode_select is not None:
             self._mode_select.set_value("tic")
-        # Rebuild the aggregate BEFORE opening the expansion. Opening first
-        # races Quasar ``after-show`` against an empty cache, which leaves the
-        # aggregate spectrum stuck on its placeholder after a page refresh.
+
+    def _clear_all_figures(self) -> None:
+        """Swap every figure to its empty placeholder so Plotly releases data."""
+        if self.plot is not None:
+            self.plot.update_figure(self._figure_with_config(self._empty_figure()))
+        if self.spectrum_plot is not None:
+            self.spectrum_plot.update_figure(
+                self._figure_with_config(self._empty_spectrum_figure())
+            )
+        if self.overlay_plot is not None:
+            self.overlay_plot.update_figure(
+                self._figure_with_config(self._empty_overlay_figure())
+            )
+
+    def _ensure_aggregate(self) -> None:
+        """Compute the aggregate spectrum once per dataset (idempotent).
+
+        Guards on ``_agg_computed`` (not on ``_agg_centers is None``) so a
+        legitimately-empty dataset is not recomputed on every emit / after-show.
+        """
+        if self._agg_computed:
+            return
+        self._recompute_aggregate()
+        self._agg_computed = True
+
+    def _cancel_render_timer(self) -> None:
+        if self._render_timer is not None:
+            try:
+                self._render_timer.cancel()
+            except Exception:
+                pass
+            self._render_timer = None
+
+    def _schedule_initial_render(self, token: int) -> None:
+        """Defer the first heavy render so page construction / first paint is not blocked."""
+        self._pending_token = token
+        self._cancel_render_timer()
+        if self.expansion is None:
+            # No element context to attach a timer to — render inline as fallback.
+            self._initial_render(token)
+            return
+        # Attach under the expansion's slot so a valid context exists even when
+        # this runs from a raw asyncio task (CLI load), where the slot stack is
+        # otherwise empty and ui.timer() would raise "current slot ...".
+        with self.expansion:
+            self._render_timer = ui.timer(
+                0.05, lambda: self._initial_render(token), once=True
+            )
+
+    def _initial_render(self, token: int) -> None:
+        """Compute + render for a scheduled load, re-validating against newer loads."""
+        self._render_timer = None
+        # A newer load may have superseded this one while the timer waited.
+        if token != self.state.msi_load_token or not self._has_data():
+            return
         try:
-            self._recompute_aggregate()
+            self._ensure_aggregate()
         except Exception as exc:
             print(f"[ImagingPanel] aggregate error: {exc}")
+        # Re-check after the (potentially slow) compute before publishing.
+        if token != self.state.msi_load_token or not self._has_data():
+            return
         try:
-            self._render_tic()
-        except Exception as exc:
-            print(f"[ImagingPanel] TIC render error: {exc}")
-        try:
-            self._render_aggregate_spectrum()
-        except Exception as exc:
-            print(f"[ImagingPanel] spectrum render error: {exc}")
-        try:
-            self._render_overlay()
-        except Exception as exc:
-            print(f"[ImagingPanel] overlay render error: {exc}")
-        # Open last so ``after-show`` re-pushes figures with the cache already
-        # populated (handles mid-animation / zero-size Plotly layout quirks).
-        if self.expansion:
-            self.expansion.value = True
-
+            for render in (
+                self._render_tic,
+                self._render_aggregate_spectrum,
+                self._render_overlay,
+            ):
+                try:
+                    render()
+                except Exception as exc:
+                    print(f"[ImagingPanel] render error: {exc}")
+        finally:
+            self._handled_token = token
+            self._pending_token = None
+            # Open last so ``after-show`` re-pushes figures with the cache
+            # populated (handles mid-animation / zero-size Plotly quirks).
+            if self.expansion:
+                self.expansion.value = True
 
     def _on_mode_change(self, mode: str) -> None:
         self._mode = mode

--- a/tests/e2e/test_imaging_panel.py
+++ b/tests/e2e/test_imaging_panel.py
@@ -1,0 +1,182 @@
+"""End-to-end (browser) tests for the Ion Image panel (imzML / MSI).
+
+Covers the parts of the PR #42 review fixes that unit tests cannot reach —
+the NiceGUI lifecycle: the panel auto-opens and renders on load, the browse
+loop (Extract → ion image) updates the heatmap, and the panel rehydrates
+after a full page reload (Fix 3: token-deduped, deferred, race-safe render).
+
+Self-contained: launches the real app as a subprocess with an imzML fixture
+and drives it with a headless Chromium. Skips cleanly when the ``e2e`` extra
+or the browser binary is not installed, so a plain ``uv run pytest`` (which
+also excludes ``-m e2e``) is unaffected.
+
+Run with:
+    uv sync --extra e2e
+    uv run playwright install chromium
+    uv run pytest tests/e2e -m e2e
+"""
+
+import contextlib
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright", reason="install the 'e2e' extra to run browser tests")
+
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+pytestmark = pytest.mark.e2e
+
+# Example_Processed.imzML has a matching .ibd alongside (required by the loader).
+DATA_FILE = Path(__file__).resolve().parents[1] / "data" / "Example_Processed.imzML"
+STARTUP_TIMEOUT_S = 90.0
+
+# Plotly figure titles set by ImagingPanel — used as robust render signals
+# instead of brittle DOM nesting.
+TIC_TITLE = "TIC Image"
+AGG_TITLE = "Mean spectrum"          # default aggregate mode
+ION_TITLE = "Ion Image  m/z"         # after Extract / peak click
+EMPTY_IMAGE_TITLE = "load an imzML file to display"
+
+# Collect every Plotly plot's layout title text (heatmaps, spectra, overlay).
+_TITLES_JS = """() => Array.from(document.querySelectorAll('.js-plotly-plot')).map(el => {
+    const t = el.layout && el.layout.title;
+    return (t && (t.text !== undefined ? t.text : t)) || '';
+})"""
+
+_HAS_TITLE_JS = """(sub) => Array.from(document.querySelectorAll('.js-plotly-plot')).some(el => {
+    const t = el.layout && el.layout.title;
+    const txt = (t && (t.text !== undefined ? t.text : t)) || '';
+    return txt.includes(sub);
+})"""
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_until_up(url: str, proc: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"viewer process exited early with code {proc.returncode}")
+        with contextlib.suppress(Exception):
+            with urllib.request.urlopen(url, timeout=1) as resp:
+                if resp.status == 200:
+                    return
+        time.sleep(0.5)
+    raise TimeoutError(f"viewer did not come up at {url} within {timeout}s")
+
+
+def _wait_for_title(page, substring: str, timeout: int = 60_000) -> None:
+    page.wait_for_function(_HAS_TITLE_JS, arg=substring, timeout=timeout)
+
+
+@pytest.fixture(scope="module")
+def imzml_url():
+    """Launch the app with an imzML file in browser mode; yield its base URL."""
+    if not DATA_FILE.exists():
+        pytest.skip(f"missing test data: {DATA_FILE}")
+    if not DATA_FILE.with_suffix(".ibd").exists():
+        pytest.skip(f"missing .ibd alongside {DATA_FILE}")
+
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}/"
+    log = tempfile.NamedTemporaryFile(
+        "w+", suffix=".log", prefix="pyopenms_viewer_e2e_imaging_", delete=False
+    )
+
+    # NiceGUI switches ui.run() into an internal test mode when PYTEST_CURRENT_TEST
+    # is set, then reads NICEGUI_SCREEN_TEST_PORT. The child must look like a
+    # normal process, so strip both from its environment.
+    child_env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("NICEGUI_") and k != "PYTEST_CURRENT_TEST"
+    }
+
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "pyopenms_viewer",
+            str(DATA_FILE), "--browser", "--no-open", "--port", str(port),
+        ],
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        env=child_env,
+    )
+    try:
+        try:
+            _wait_until_up(url, proc, STARTUP_TIMEOUT_S)
+        except Exception as exc:
+            log.flush()
+            output = Path(log.name).read_text(errors="replace")[-4000:]
+            raise RuntimeError(f"{exc}\n--- viewer output ---\n{output}") from exc
+        yield url
+    finally:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)
+        if proc.poll() is None:
+            proc.kill()
+        log.close()
+        with contextlib.suppress(OSError):
+            Path(log.name).unlink()
+
+
+@pytest.fixture
+def page(imzml_url):
+    """A fresh headless page on the running imzML viewer."""
+    with sync_playwright() as p:
+        try:
+            browser = p.chromium.launch(headless=True)
+        except Exception as exc:  # browser binary not installed
+            pytest.skip(f"chromium unavailable (run 'playwright install chromium'): {exc}")
+        ctx = browser.new_context(viewport={"width": 1600, "height": 1200})
+        pg = ctx.new_page()
+        pg.goto(imzml_url, wait_until="networkidle")
+        try:
+            yield pg
+        finally:
+            ctx.close()
+            browser.close()
+
+
+def test_ion_image_renders_and_extract_updates(page):
+    """On load the Ion Image panel shows the TIC image + aggregate spectrum,
+    and the Extract browse loop swaps the heatmap to an ion image."""
+    # Panel auto-opens and renders the TIC image + aggregate spectrum.
+    _wait_for_title(page, TIC_TITLE)
+    _wait_for_title(page, AGG_TITLE)
+
+    # Browse loop: Extract at the default m/z must flip the heatmap title.
+    page.get_by_role("button", name="Extract", exact=True).first.click()
+    _wait_for_title(page, ION_TITLE, timeout=30_000)
+
+    titles = page.evaluate(_TITLES_JS)
+    assert any(ION_TITLE in t for t in titles), titles
+    # The image is no longer the empty placeholder.
+    assert not any(EMPTY_IMAGE_TITLE in t for t in titles), titles
+
+
+def test_panel_rehydrates_after_reload(page):
+    """A full page reload must rehydrate the Ion Image panel (Fix 3), not leave
+    it stuck on the empty placeholder."""
+    _wait_for_title(page, TIC_TITLE)
+
+    page.reload(wait_until="networkidle")
+
+    # After reload the panel must render the TIC image again from preserved
+    # server-side state — exactly the rehydration path the fix targets.
+    _wait_for_title(page, TIC_TITLE)
+    _wait_for_title(page, AGG_TITLE)
+    titles = page.evaluate(_TITLES_JS)
+    assert not any(EMPTY_IMAGE_TITLE in t for t in titles), titles

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -312,3 +312,42 @@ def test_has_data_false_when_no_msi_experiment():
     state.msi_experiment = None  # simulate missing experiment
     panel = ImagingPanel(state)
     assert panel._has_data() is False
+
+
+# -------------------------------------------------------------------------
+# ImagingPanel aggregate idempotency (rehydration dedupe)
+# -------------------------------------------------------------------------
+
+class TestEnsureAggregateIdempotent:
+    def test_ensure_aggregate_computes_once(self):
+        state = _loaded_state(EXAMPLE_IMZML_CONTINUOUS)
+        panel = ImagingPanel(state)
+
+        calls = {"n": 0}
+        real = panel._recompute_aggregate
+
+        def counting():
+            calls["n"] += 1
+            real()
+
+        panel._recompute_aggregate = counting
+        panel._ensure_aggregate()
+        panel._ensure_aggregate()
+        panel._ensure_aggregate()
+        assert calls["n"] == 1  # recomputed once despite repeated calls
+        assert panel._agg_computed is True
+
+    def test_reset_view_and_caches_reallows_compute(self):
+        state = _loaded_state(EXAMPLE_IMZML_CONTINUOUS)
+        panel = ImagingPanel(state)
+        panel._ensure_aggregate()
+        assert panel._agg_computed is True
+        # Populate caches, then reset (as a new load would).
+        panel._tic_cache = np.zeros((2, 2))
+        panel._overlay_entries.append({"mz": 1.0, "ppm": 1.0, "hue": (0, 0, 0), "img": None})
+        panel._reset_view_and_caches()
+        assert panel._agg_computed is False
+        assert panel._tic_cache is None
+        assert panel._overlay_entries == []
+        assert panel._mode == "tic"
+        assert panel._current_mz is None

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -178,6 +178,103 @@ class TestImzMLLoading:
         assert img.shape[0] > 0 and img.shape[1] > 0
         assert np.nansum(img) > 0
 
+    def test_load_imzml_bumps_load_token(self):
+        """Each successful imzML load must advance state.msi_load_token."""
+        state = ViewerState()
+        loader = ImzMLLoader(state)
+        before = state.msi_load_token
+        assert loader.load_sync(str(EXAMPLE_IMZML)) is True
+        assert state.msi_load_token == before + 1
+
+    def test_mzml_load_clears_stale_msi_state(self):
+        """Loading a plain mzML after an imzML must clear has_imzml/msi_experiment.
+
+        Otherwise the Ion Image panel keeps rendering the previous MSI
+        experiment beside the new mzML data.
+        """
+        state = ViewerState()
+        assert ImzMLLoader(state).load_sync(str(EXAMPLE_IMZML)) is True
+        assert state.has_imzml is True and state.msi_experiment is not None
+
+        assert MzMLLoader(state).load_sync(str(BSA_MZML)) is True
+        assert state.has_imzml is False
+        assert state.msi_experiment is None
+
+
+class TestSelectPositiveIntensityPeaks:
+    """The zero-intensity drop must keep per-peak arrays (e.g. IM) aligned."""
+
+    def test_filters_peaks_and_float_data_arrays_together(self):
+        import pyopenms as oms
+
+        from pyopenms_viewer.loaders.imzml_loader import (
+            _select_positive_intensity_peaks,
+        )
+
+        spec = oms.MSSpectrum()
+        spec.set_peaks((
+            np.array([100.0, 200.0, 300.0]),
+            np.array([0.0, 5.0, 0.0], dtype=np.float32),
+        ))
+        fda = oms.FloatDataArray()
+        fda.setName("inverse reduced ion mobility")
+        fda.set_data(np.array([1.1, 2.2, 3.3], dtype=np.float32))
+        spec.setFloatDataArrays([fda])
+
+        _select_positive_intensity_peaks(spec)
+
+        mzs, ints = spec.get_peaks()
+        im = np.asarray(spec.getFloatDataArrays()[0].get_data())
+        # set_peaks would have left im at length 3 (misaligned); select() keeps
+        # peaks and the IM array aligned to the surviving peak.
+        assert list(mzs) == [200.0]
+        assert list(ints) == [5.0]
+        assert len(im) == len(mzs)
+        assert im[0] == np.float32(2.2)
+
+    def test_all_zero_spectrum_becomes_empty(self):
+        import pyopenms as oms
+
+        from pyopenms_viewer.loaders.imzml_loader import (
+            _select_positive_intensity_peaks,
+        )
+
+        spec = oms.MSSpectrum()
+        spec.set_peaks((np.array([100.0, 200.0]), np.array([0.0, 0.0], dtype=np.float32)))
+        _select_positive_intensity_peaks(spec)
+        mzs, _ = spec.get_peaks()
+        assert len(mzs) == 0
+
+    def test_untouched_when_all_positive(self):
+        import pyopenms as oms
+
+        from pyopenms_viewer.loaders.imzml_loader import (
+            _select_positive_intensity_peaks,
+        )
+
+        spec = oms.MSSpectrum()
+        spec.set_peaks((np.array([100.0, 200.0]), np.array([3.0, 5.0], dtype=np.float32)))
+        _select_positive_intensity_peaks(spec)
+        mzs, ints = spec.get_peaks()
+        assert list(mzs) == [100.0, 200.0]
+        assert list(ints) == [3.0, 5.0]
+
+
+class TestExtractSpectrumDataExpOverride:
+    """extract_spectrum_data must honour an explicit `exp=` without touching state."""
+
+    def test_exp_override_used_and_state_untouched(self):
+        from pyopenms_viewer.loaders import extract_spectrum_data
+
+        state = ViewerState()
+        assert MzMLLoader(state).load_sync(str(BSA_MZML)) is True
+        exp = state.exp
+
+        fresh = ViewerState()  # state.exp is None here
+        data = extract_spectrum_data(fresh, exp=exp)
+        assert len(data) == len(exp)
+        assert fresh.exp is None  # override must not mutate the passed state
+
 
 class TestChromatogramExtraction:
     """Tests for chromatogram extraction."""


### PR DESCRIPTION
#42 has now been **merged** (squash commit `Ion image panel (#42)`). This branch was previously stacked on #42's pre-merge branch, which made it show as *CONFLICTING*. It has now been **rebased onto `main`**, dropping the duplicated #42 commits, so it reduces to a single fix commit on top of the merged code.

These fixes address findings from the review of #42 that are still present on `main`:

- **IM misalignment (HIGH)** — zero-intensity peak filtering used `set_peaks`, which shortens the peak arrays but leaves the associated `FloatDataArrays` (per-peak ion mobility) at their old length, silently breaking IM detection. Now filters with `MSSpectrum.select([...])` so peaks and all data arrays stay aligned.
- **Stale MSI state (HIGH)** — loading a plain mzML after an imzML now clears `has_imzml`/`msi_experiment`, so the Ion Image panel stops rendering the previous MSI experiment.
- **Atomic load (MED)** — extract spectrum metadata via a new keyword-only `exp=` override instead of assigning `state.exp` before the commit; the IM step is best-effort so a failure no longer discards an otherwise-valid load.
- **Rehydration lifecycle (MED)** — `state.msi_load_token` lets the Ion Image panel dedupe repeated `data_loaded` emits (normal load / page-reload / CLI fast-path), defer the heavy aggregate off the page-build path via a one-shot `ui.timer`, and re-validate the token before compute and before publish. `after-show` and the initial render share an idempotent `_ensure_aggregate()`. (Replaces the synchronous per-emit recompute that `main` still does.)
- **Cache release (LOW)** — imaging caches/overlay freed and figures blanked when switching away from imzML.
- **Load re-entrancy (MED)** — `load_imzml` gets the same in-progress `_LOAD_EVENTS` guard as `load_mzml`.

## Tests
- Unit: IM-alignment (+ all-zero / all-positive), imzML→mzML MSI-state clear, load-token bump, `extract_spectrum_data` `exp=` override, aggregate idempotency.
- **Playwright e2e** (`tests/e2e/test_imaging_panel.py`, opt-in `e2e` extra + marker): panel renders TIC image + aggregate spectrum on load, the Extract browse loop swaps to an ion image, and the panel rehydrates after a full page reload.

Full suite after rebase: **356 passed, 4 skipped** (e2e deselected by default). The one failing test (`test_export.py::...test_original_experiment_not_modified`) is pre-existing on `main` and unrelated — `export_panel.py` assumes `getSpectrum()` returns a copy while the pinned pyOpenMS dev build returns a live reference; this branch touches no export code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)